### PR TITLE
修改async_move宏支持无事件参数的情况

### DIFF
--- a/src/bot/plugin_builder.rs
+++ b/src/bot/plugin_builder.rs
@@ -323,7 +323,7 @@ impl PluginBuilder {
 #[macro_export]
 macro_rules! async_move {
     // 匹配没有事件参数的情况
-    (; $($var:ident),*; $($body:tt)*) => {
+    (;$($var:ident),*; $($body:tt)*) => {
         {
             $(let $var = $var.clone();)*
             move || {
@@ -343,6 +343,15 @@ macro_rules! async_move {
                 async move
                     $($body)*
             }
+        }
+    };
+
+    // 匹配只要一次clone的情况（自己tokio::spawn一个新线程）
+    ($($var:ident),*;$($body:tt)*) => {
+        {
+            $(let $var = $var.clone();)*
+            async move
+                $($body)*
         }
     };
 }

--- a/src/bot/plugin_builder.rs
+++ b/src/bot/plugin_builder.rs
@@ -320,9 +320,21 @@ impl PluginBuilder {
     }
 }
 
-
 #[macro_export]
-macro_rules! async_move  {
+macro_rules! async_move {
+    // 匹配没有事件参数的情况
+    (; $($var:ident),*; $($body:tt)*) => {
+        {
+            $(let $var = $var.clone();)*
+            move || {
+                $(let $var = $var.clone();)*
+                async move
+                    $($body)*
+            }
+        }
+    };
+
+    // 匹配有事件参数的情况
     ($event:ident; $($var:ident),*; $($body:tt)*) => {
         {
             $(let $var = $var.clone();)*


### PR DESCRIPTION
如在定时任务中是没有事件参数的，如

> p::cron("0 0 7-22 * * ?", async_move!(;bot,db,times,on,skip_set;{});

而在消息处理中需要填事件参数，如

> p::on_admin_msg(async_move!(event;on,times,db,bot,skip_set;{});