### PR TITLE
fix: action of set_group_add_request

### DIFF
--- a/src/bot/runtimebot/onebot_api.rs
+++ b/src/bot/runtimebot/onebot_api.rs
@@ -641,7 +641,7 @@ impl RuntimeBot {
             AddRequestType::Type(v) => ("type", v),
         };
         let send_api = SendApi::new(
-            "set_friend_add_request",
+            "set_group_add_request",
             json!({
                 "flag":flag,
                     type_: type_value,


### PR DESCRIPTION
In `set_group_add_request`, the action name is wrongly set to `set_friend_add_request`. Fix this bug.