### PR TITLE
WS 断开后自动重连，不再退出程序

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ members = [
     "kovi-onebot",
     "kovi-macros",
     "kovi-milky",
-    "plugins/*",
 ]
 
 [workspace.dependencies]

--- a/kovi-onebot/src/driver.rs
+++ b/kovi-onebot/src/driver.rs
@@ -2,12 +2,13 @@ use std::sync::Arc;
 
 use crate::driver::config::{OneBotDriverConfig, Server};
 use crate::driver::connect::api_cnt::{OneBotApiOneshotSender, OneBotSendApi};
+use crate::driver::config::ReconnectConfig;
 use crate::event::MsgEvent;
 use kovi::bot::SendApi;
 use kovi::driver::{Driver, DriverEvent, MessageEventRegister};
 use kovi::futures_util;
 use log::{error, info};
-use tokio::sync::{Mutex, OnceCell, mpsc};
+use tokio::sync::mpsc;
 
 pub mod config;
 pub(crate) mod connect;
@@ -31,13 +32,15 @@ pub(crate) struct ApiContext {
     _tasks: Vec<AbortOnDrop>,
 }
 
-pub type EventTx = Arc<Mutex<Option<mpsc::Sender<Result<DriverEvent, kovi::driver::AnyError>>>>>;
+/// API 连接上下文的共享槽位：`None` 表示未连接；断开时后台任务将其置回 `None` 以便自动重连
+pub(crate) type ApiContextSlot = Arc<tokio::sync::Mutex<Option<ApiContext>>>;
 
 pub struct OneBotDriver {
     pub(crate) server: Arc<Server>,
-    /// 异步 OnceCell：保证并发时只初始化一次
-    ctx: Arc<OnceCell<ApiContext>>,
-    pub(crate) event_tx: EventTx,
+    /// API 连接上下文：连接断开时后台任务会将其置回 `None`，下次调用时自动重连
+    ctx: ApiContextSlot,
+    /// 事件通道断开后的自动重连参数
+    reconnect: ReconnectConfig,
 }
 
 impl OneBotDriver {
@@ -46,8 +49,8 @@ impl OneBotDriver {
 
         Self {
             server: Arc::new(config.server),
-            ctx: Arc::new(OnceCell::new()),
-            event_tx: Arc::new(Mutex::new(None)),
+            ctx: Arc::new(tokio::sync::Mutex::new(None)),
+            reconnect: config.reconnect,
         }
     }
 }
@@ -64,12 +67,6 @@ impl Driver for OneBotDriver {
         >,
         kovi::driver::AnyError,
     > {
-        let (event_tx, event_rx) = mpsc::channel(64);
-        {
-            let mut guard = self.event_tx.lock().await;
-            *guard = Some(event_tx);
-        }
-
         match self.handler_lifecycle_log_bot_enable().await {
             Ok(_) => {}
             Err(_) => {
@@ -78,47 +75,37 @@ impl Driver for OneBotDriver {
             }
         };
 
-        OneBotDriver::ws_event_connect((*self.server).clone(), event_rx).await
+        OneBotDriver::ws_event_connect((*self.server).clone()).await
     }
 
     fn api_handler(
         &self,
         value: kovi::bot::SendApi,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<
-                    Output = Result<
-                        Result<kovi::ApiReturn, kovi::ApiReturn>,
-                        kovi::driver::AnyError,
-                    >,
-                > + Send,
-        >,
-    > {
-        if self.ctx.initialized() {
-            let ctx = Arc::clone(&self.ctx);
-            Box::pin(async move {
-                // 初始化后只用 api_tx（Sender clone 极廉价），server 不再传入热路径
-                let api_tx = ctx.get().expect("unreachable").api_tx.clone();
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<Result<kovi::ApiReturn, kovi::ApiReturn>, kovi::driver::AnyError>> + Send>> {
+        let server = Arc::clone(&self.server);
+        let self_ctx = Arc::clone(&self.ctx);
+        Box::pin(async move {
+            // 每次调用都确保上下文就绪；断开后被重置为 None，这里会自动重连
+            let mut guard = self_ctx.lock().await;
+            if guard.is_none() {
+                match OneBotDriver::init_api_context(server, Arc::clone(&self_ctx)).await {
+                    Ok(api_ctx) => *guard = Some(api_ctx),
+                    Err(err) => return Err(err),
+                }
+            }
+            let api_tx = guard.as_ref().expect("unreachable").api_tx.clone();
+            drop(guard);
 
-                OneBotDriver::send_api_inner(api_tx, value).await
-            })
-        } else {
-            let server = Arc::clone(&self.server);
-            let event_tx = Arc::clone(&self.event_tx);
-            let self_ctx = Arc::clone(&self.ctx);
-            Box::pin(async move {
-                let api_tx = self_ctx
-                    .get_or_try_init(|| OneBotDriver::init_api_context(server, event_tx))
-                    .await?
-                    .api_tx
-                    .clone();
-                OneBotDriver::send_api_inner(api_tx, value).await
-            })
-        }
+            OneBotDriver::send_api_inner(api_tx, value).await
+        })
     }
 
     fn message_event_register(&self) -> MessageEventRegister {
         MessageEventRegister::register::<MsgEvent>()
+    }
+
+    fn reconnect_config(&self) -> kovi::driver::ReconnectConfig {
+        self.reconnect.to_kovi()
     }
 }
 
@@ -172,5 +159,195 @@ impl OneBotDriver {
         info!("Bot connection successful，Nickname:{self_name},ID:{self_id}");
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::{SinkExt, StreamExt};
+    use kovi::tokio;
+    use serde_json::Value;
+    use std::net::Ipv4Addr;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::tungstenite::Message;
+    use tokio_tungstenite::{accept_async, WebSocketStream};
+
+    /// 服务端断开方式
+    #[derive(Copy, Clone)]
+    enum CloseMode {
+        /// 正常发送 Close 帧
+        CleanClose,
+        /// 直接丢弃连接（读端报错）
+        AbruptDrop,
+    }
+
+    /// 模拟 OneBot API WS 服务端：每连接处理一条请求并回包，然后按 mode 断开
+    async fn spawn_api_server(
+        mode: CloseMode,
+        conn_count: Arc<AtomicUsize>,
+    ) -> (u16, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("bind test server");
+        let port = listener.local_addr().expect("local addr").port();
+
+        let handle = tokio::spawn(async move {
+            loop {
+                let (stream, _) = match listener.accept().await {
+                    Ok(v) => v,
+                    Err(_) => break,
+                };
+                conn_count.fetch_add(1, Ordering::SeqCst);
+
+                tokio::spawn(async move {
+                    let mut ws: WebSocketStream<_> =
+                        accept_async(stream).await.expect("ws accept");
+
+                    // 处理一条 API 请求
+                    let msg = ws.next().await.expect("api request").expect("msg");
+                    if let Message::Text(text) = msg {
+                        let req: Value = serde_json::from_str(&text).expect("req json");
+                        let echo = req["echo"].as_str().expect("echo");
+                        let reply = serde_json::json!({
+                            "status": "ok",
+                            "retcode": 0,
+                            "data": { "user_id": 1, "nickname": "test-bot" },
+                            "echo": echo,
+                        });
+                        ws.send(Message::text(reply.to_string()))
+                            .await
+                            .expect("send reply");
+                    }
+
+                    match mode {
+                        CloseMode::CleanClose => {
+                            ws.close(None).await.expect("close handshake");
+                        }
+                        CloseMode::AbruptDrop => {}
+                    }
+                });
+            }
+        });
+
+        (port, handle)
+    }
+
+    fn driver_for(port: u16) -> OneBotDriver {
+        OneBotDriver::new(OneBotDriverConfig {
+            server: Server {
+                host: crate::driver::config::Host::IpAddr(std::net::IpAddr::V4(
+                    Ipv4Addr::LOCALHOST,
+                )),
+                port,
+                access_token: String::new(),
+                secure: false,
+                path: "/".to_string(),
+                all_in_one: true,
+            },
+            reconnect: ReconnectConfig::default(),
+        })
+    }
+
+    /// 等待 API 上下文被后台任务重置（连接断开被感知）
+    async fn wait_ctx_reset(driver: &OneBotDriver) {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if driver.ctx.lock().await.is_none() {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("API context should be reset after disconnect");
+    }
+
+    async fn assert_one_call_succeeds(driver: &OneBotDriver) {
+        let api = SendApi::new("get_login_info", serde_json::json!({}));
+        let res = driver
+            .api_handler(api)
+            .await
+            .expect("api handler should succeed")
+            .expect("api return should be ok");
+        assert_eq!(res.data["user_id"], 1);
+    }
+
+    async fn run_reconnect_scenario(mode: CloseMode) {
+        let conn_count = Arc::new(AtomicUsize::new(0));
+        let (port, _server) = spawn_api_server(mode, Arc::clone(&conn_count)).await;
+        let driver = driver_for(port);
+
+        // 首次调用：建立第一条连接并成功
+        assert_one_call_succeeds(&driver).await;
+        assert_eq!(conn_count.load(Ordering::SeqCst), 1);
+
+        // 等待服务端断开被感知（上下文重置）
+        wait_ctx_reset(&driver).await;
+
+        // 再次调用：应自动建立新连接并成功
+        assert_one_call_succeeds(&driver).await;
+        assert_eq!(conn_count.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn api_reconnects_after_clean_close() {
+        run_reconnect_scenario(CloseMode::CleanClose).await;
+    }
+
+    #[tokio::test]
+    async fn api_reconnects_after_abrupt_drop() {
+        run_reconnect_scenario(CloseMode::AbruptDrop).await;
+    }
+
+    #[test]
+    fn reconnect_config_is_honored() {
+        let driver = OneBotDriver::new(OneBotDriverConfig {
+            server: Server {
+                host: crate::driver::config::Host::IpAddr(std::net::IpAddr::V4(
+                    Ipv4Addr::LOCALHOST,
+                )),
+                port: 8081,
+                access_token: String::new(),
+                secure: false,
+                path: "/".to_string(),
+                all_in_one: true,
+            },
+            reconnect: ReconnectConfig {
+                base_delay_secs: 3,
+                max_delay_secs: 60,
+            },
+        });
+
+        let config = driver.reconnect_config();
+        assert_eq!(config.base_delay, Duration::from_secs(3));
+        assert_eq!(config.max_delay, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn reconnect_config_normalizes_invalid_values() {
+        // base 为 0 → 至少 1s；max 小于 base → 提升到 base
+        let config = OneBotDriverConfig {
+            server: Server {
+                host: crate::driver::config::Host::IpAddr(std::net::IpAddr::V4(
+                    Ipv4Addr::LOCALHOST,
+                )),
+                port: 8081,
+                access_token: String::new(),
+                secure: false,
+                path: "/".to_string(),
+                all_in_one: true,
+            },
+            reconnect: ReconnectConfig {
+                base_delay_secs: 0,
+                max_delay_secs: 0,
+            },
+        }
+        .normalize_path();
+
+        assert_eq!(config.reconnect.base_delay_secs, 1);
+        assert_eq!(config.reconnect.max_delay_secs, 1);
     }
 }

--- a/kovi-onebot/src/driver/config.rs
+++ b/kovi-onebot/src/driver/config.rs
@@ -11,6 +11,9 @@ use std::path::Path;
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct OneBotDriverConfig {
     pub server: Server,
+    /// 事件通道断开后的自动重连参数
+    #[serde(default)]
+    pub reconnect: ReconnectConfig,
 }
 
 impl OneBotDriverConfig {
@@ -28,6 +31,55 @@ impl OneBotDriverConfig {
                 },
                 all_in_one: self.server.all_in_one,
             },
+            reconnect: self.reconnect.normalize(),
+        }
+    }
+}
+
+/// 事件通道断开后的自动重连参数
+///
+/// 断开后以 `base_delay_secs` 起步重试，每次翻倍，封顶 `max_delay_secs`。
+/// 连接成功后会重置回 `base_delay_secs`。
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+pub struct ReconnectConfig {
+    /// 首次重连延迟（秒），默认 1
+    #[serde(default = "default_base_delay_secs")]
+    pub base_delay_secs: u64,
+    /// 重连延迟上限（秒），默认 30
+    #[serde(default = "default_max_delay_secs")]
+    pub max_delay_secs: u64,
+}
+
+fn default_base_delay_secs() -> u64 {
+    1
+}
+
+fn default_max_delay_secs() -> u64 {
+    30
+}
+
+impl Default for ReconnectConfig {
+    fn default() -> Self {
+        Self {
+            base_delay_secs: default_base_delay_secs(),
+            max_delay_secs: default_max_delay_secs(),
+        }
+    }
+}
+
+impl ReconnectConfig {
+    /// 归一化：首延迟至少 1s，封顶不小于首延迟
+    fn normalize(mut self) -> Self {
+        self.base_delay_secs = self.base_delay_secs.max(1);
+        self.max_delay_secs = self.max_delay_secs.max(self.base_delay_secs);
+        self
+    }
+
+    /// 转为核心 `ReconnectConfig`
+    pub(crate) fn to_kovi(self) -> kovi::driver::ReconnectConfig {
+        kovi::driver::ReconnectConfig {
+            base_delay: std::time::Duration::from_secs(self.base_delay_secs),
+            max_delay: std::time::Duration::from_secs(self.max_delay_secs),
         }
     }
 }
@@ -237,6 +289,7 @@ fn config_file_write_and_return(file_path: &Path) -> Result<OneBotDriverConfig, 
             path,
             all_in_one,
         },
+        reconnect: ReconnectConfig::default(),
     };
 
     let mut doc = match fs::read_to_string(file_path) {
@@ -264,6 +317,10 @@ fn config_file_write_and_return(file_path: &Path) -> Result<OneBotDriverConfig, 
     doc["server"]["path"] = toml_edit::value(&config.server.path);
     doc["server"]["all_in_one"] = toml_edit::value(config.server.all_in_one);
 
+    doc["reconnect"] = toml_edit::table();
+    doc["reconnect"]["base_delay_secs"] = toml_edit::value(config.reconnect.base_delay_secs as i64);
+    doc["reconnect"]["max_delay_secs"] = toml_edit::value(config.reconnect.max_delay_secs as i64);
+
     let file = fs::File::create(file_path)?;
     let mut writer = std::io::BufWriter::new(file);
     writer.write_all(doc.to_string().as_bytes())?;
@@ -276,19 +333,11 @@ pub fn load_local_conf() -> Result<OneBotDriverConfig, BotBuildError> {
     let path = Path::new("kovi.conf.toml");
     let kovi_conf_file_exist = fs::metadata(path).is_ok();
 
-    #[derive(Deserialize, Serialize, Debug, Clone)]
-    struct TempKoviConfig {
-        server: Option<Server>,
-    }
-
     let conf_json: OneBotDriverConfig = if kovi_conf_file_exist {
         match fs::read_to_string(path) {
-            Ok(v) => match toml::from_str::<TempKoviConfig>(&v) {
-                Ok(conf) => match conf.server {
-                    Some(server) => OneBotDriverConfig { server },
-                    None => config_file_write_and_return(path)
-                        .map_err(|e| BotBuildError::FileCreateError(e.to_string()))?,
-                },
+            Ok(v) => match toml::from_str::<OneBotDriverConfig>(&v) {
+                // server 缺失时视为无效配置，重新交互式生成
+                Ok(conf) => conf,
                 Err(err) => {
                     eprintln!("Configuration file parsing error: {err}");
                     config_file_write_and_return(path)

--- a/kovi-onebot/src/driver/connect/api_cnt.rs
+++ b/kovi-onebot/src/driver/connect/api_cnt.rs
@@ -1,11 +1,11 @@
 use crate::driver::config::Server;
-use crate::driver::{self, AbortOnDrop, EventTx, OneshotTxMap};
+use crate::driver::{self, AbortOnDrop, ApiContextSlot, OneshotTxMap};
 use ahash::RandomState;
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use http::HeaderValue;
 use kovi::bot::SendApi;
-use kovi::driver::{AnyError, DriverEvent};
+use kovi::driver::AnyError;
 use kovi::{ApiReturn, futures_util};
 use log::{debug, error, warn};
 use serde::{Deserialize, Serialize};
@@ -91,9 +91,12 @@ impl driver::OneBotDriver {
     }
 
     /// 冷路径：建立 WS 连接并启动后台任务，返回 ApiContext（只在首次调用时执行）
+    ///
+    /// 连接断开时（Close 帧 / 读错误 / 写错误）后台任务会把共享槽位置回 `None`，
+    /// 使下一次 API 调用重新走冷路径建立新连接，实现自动重连。
     pub(crate) async fn init_api_context(
         server: Arc<Server>,
-        event_tx: EventTx,
+        ctx: ApiContextSlot,
     ) -> Result<driver::ApiContext, AnyError> {
         let mut request = server
             .ws_url("api")
@@ -126,9 +129,15 @@ impl driver::OneBotDriver {
                 read,
                 ctrl_tx,
                 Arc::clone(&tx_map),
-                Arc::clone(&event_tx),
+                Arc::clone(&ctx),
             ))),
-            AbortOnDrop(tokio::spawn(ws_write_task(write, api_rx, ctrl_rx, tx_map))),
+            AbortOnDrop(tokio::spawn(ws_write_task(
+                write,
+                api_rx,
+                ctrl_rx,
+                tx_map,
+                ctx,
+            ))),
         ];
 
         Ok(driver::ApiContext {
@@ -143,27 +152,30 @@ async fn ws_read_task(
     read: SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>,
     ctrl_tx: mpsc::UnboundedSender<Message>,
     tx_map: OneshotTxMap,
-    event_tx: EventTx,
+    ctx: ApiContextSlot,
 ) {
     read.for_each(|msg| {
         let ctrl_tx = ctrl_tx.clone();
         let tx_map = tx_map.clone();
-        let event_tx = Arc::clone(&event_tx);
+        let ctx = Arc::clone(&ctx);
         async move {
             let msg = match msg {
                 Ok(m) => m,
                 Err(e) => {
-                    error!("WS read error: {e}");
+                    error!("WS read error: {e}; API connection will be re-established on next call");
+                    // 置空上下文（同时丢弃 ApiContext，中止读写任务），下次调用时自动重连
+                    *ctx.lock().await = None;
                     return;
                 }
             };
 
             match msg {
                 Message::Close(frame) => {
-                    warn!("API WS connection closed by remote");
+                    warn!("API WS connection closed by remote; reconnecting on next call");
                     // 回发 Close 完成关闭握手
                     let _ = ctrl_tx.send(Message::Close(frame));
-                    send_exit_event(&event_tx).await;
+                    // 置空上下文（同时丢弃 ApiContext，中止读写任务），下次调用时自动重连
+                    *ctx.lock().await = None;
                 }
                 Message::Ping(data) => {
                     // 即使 tungstenite 内部已自动回复，兜底处理
@@ -213,6 +225,7 @@ async fn ws_write_task(
     mut api_rx: mpsc::Receiver<(OneBotSendApi, Option<OneBotApiOneshotSender>)>,
     mut ctrl_rx: mpsc::UnboundedReceiver<Message>,
     tx_map: OneshotTxMap,
+    ctx: ApiContextSlot,
 ) {
     loop {
         tokio::select! {
@@ -224,30 +237,21 @@ async fn ws_write_task(
                 }
 
                 if let Err(e) = write.send(Message::text(api_msg.to_string())).await {
-                    error!("WS write error: {e}");
+                    error!("WS write error: {e}; API connection will be re-established on next call");
+                    // 置空上下文（同时丢弃 ApiContext，中止读写任务），下次调用时自动重连
+                    *ctx.lock().await = None;
                     return;
                 }
             }
             Some(msg) = ctrl_rx.recv() => {
                 if let Err(e) = write.send(msg).await {
-                    error!("WS write error (control): {e}");
+                    error!("WS write error (control): {e}; API connection will be re-established on next call");
+                    // 置空上下文（同时丢弃 ApiContext，中止读写任务），下次调用时自动重连
+                    *ctx.lock().await = None;
                     return;
                 }
             }
             else => break,
         }
-    }
-}
-
-async fn send_exit_event(event_tx: &EventTx) {
-    let tx = {
-        let guard = event_tx.lock().await;
-        guard.as_ref().cloned()
-    };
-
-    if let Some(tx) = tx
-        && tx.send(Ok(DriverEvent::Exit)).await.is_err()
-    {
-        debug!("Failed to forward DriveEvent::Exit to event channel");
     }
 }

--- a/kovi-onebot/src/driver/connect/event_cnt.rs
+++ b/kovi-onebot/src/driver/connect/event_cnt.rs
@@ -1,7 +1,6 @@
 use crate::driver::config::Server;
 use crate::driver::{self};
-use futures_util::stream::Select;
-use futures_util::{SinkExt, StreamExt, stream};
+use futures_util::{SinkExt, StreamExt};
 use http::HeaderValue;
 use kovi::driver::{AnyError, DriverEvent};
 use kovi::futures_util;
@@ -65,7 +64,6 @@ impl futures_util::Stream for WsEventStream {
 impl driver::OneBotDriver {
     pub(crate) async fn ws_event_connect(
         server: Server,
-        event_rx: tokio::sync::mpsc::Receiver<Result<DriverEvent, AnyError>>,
     ) -> Result<
         std::pin::Pin<
             Box<
@@ -94,11 +92,6 @@ impl driver::OneBotDriver {
             closed: false,
         };
 
-        let injected_stream = stream::unfold(event_rx, |mut rx| async move {
-            rx.recv().await.map(|item| (item, rx))
-        });
-        let stream: Select<_, _> = stream::select(ws_stream, injected_stream);
-
-        Ok(Box::pin(stream))
+        Ok(Box::pin(ws_stream))
     }
 }

--- a/kovi/src/bot/run.rs
+++ b/kovi/src/bot/run.rs
@@ -30,7 +30,9 @@ impl Bot {
 
     /// 运行bot
     ///
-    /// **注意此函数会阻塞, 直到Bot连接失效，或者有退出信号传入程序**
+    /// **注意此函数会阻塞，直到收到退出信号，或驱动器主动发起退出**
+    ///
+    /// 与服务器的连接断开时会自动重连（指数退避，1s 起，30s 封顶），不会因此退出。
     pub async fn run(self) -> ExitEvent {
         let bot = Arc::new(RwLock::new(self));
         Self::run_bot_inner(bot).await

--- a/kovi/src/bot/run/connect.rs
+++ b/kovi/src/bot/run/connect.rs
@@ -1,7 +1,7 @@
 use crate::ExitEvent;
 use crate::bot::ApiReturn;
 use crate::bot::handler::InternalInternalEvent;
-use crate::driver::{Driver, DriverEvent};
+use crate::driver::{Driver, DriverEvent, ReconnectConfig};
 use crate::event::InternalEvent;
 use crate::types::ApiAndOptOneshot;
 use futures::StreamExt as _;
@@ -12,34 +12,65 @@ pub(crate) async fn event_connect(
     self_event_tx: mpsc::Sender<InternalInternalEvent>,
     drive: Arc<dyn Driver>,
 ) {
-    let mut drive_stream = match drive.event_channel().await {
-        Ok(drive_stream) => drive_stream,
-        Err(err) => {
-            eprintln!("Failed to get drive event channel: {}", err);
-            self_event_tx.send(InternalInternalEvent::Exit(ExitEvent::FromDrive)).await.expect("Kovi kernel encountered an unrecoverable error during message forwarding (channel closed)");
-            return;
-        }
-    };
+    // 重连退避参数由驱动提供，默认 1s 起步、指数增长、30s 封顶
+    let ReconnectConfig {
+        base_delay,
+        max_delay,
+    } = drive.reconnect_config();
+    let mut retry_delay = base_delay;
 
-    //处理事件，每个事件都会来到这里
-    while let Some(event) = drive_stream.next().await {
-        let event = match event {
-            Ok(event) => event,
+    loop {
+        let mut drive_stream = match drive.event_channel().await {
+            Ok(drive_stream) => drive_stream,
             Err(err) => {
-                eprintln!("Failed to get drive event: {}", err);
-                self_event_tx.send(InternalInternalEvent::Exit(ExitEvent::FromDrive)).await.expect("Kovi kernel encountered an unrecoverable error during message forwarding (channel closed)");
-                return;
+                eprintln!("Failed to get drive event channel: {err}; retrying in {retry_delay:?}");
+                tokio::time::sleep(retry_delay).await;
+                retry_delay = (retry_delay * 2).min(max_delay);
+                continue;
             }
         };
 
-        let internal_event = match event {
-            DriverEvent::Exit => InternalInternalEvent::Exit(ExitEvent::FromDrive),
-            DriverEvent::Normal(value) => {
-                InternalInternalEvent::OneBotEvent(Box::new(InternalEvent::DriverEvent(value)))
-            }
-        };
+        // 连接成功，重置
+        retry_delay = base_delay;
 
-        self_event_tx.send(internal_event).await.expect("Kovi kernel encountered an unrecoverable error during message forwarding (channel closed)");
+        //处理事件，每个事件都会来到这里
+        let mut connection_lost = false;
+        while let Some(event) = drive_stream.next().await {
+            let event = match event {
+                Ok(event) => event,
+                Err(err) => {
+                    eprintln!("Failed to get drive event: {err}");
+                    connection_lost = true;
+                    break;
+                }
+            };
+
+            match event {
+                DriverEvent::Exit => {
+                    self_event_tx
+                        .send(InternalInternalEvent::Exit(ExitEvent::FromDrive))
+                        .await
+                        .expect("Kovi kernel encountered an unrecoverable error during message forwarding (channel closed)");
+                    return;
+                }
+                DriverEvent::Normal(value) => {
+                    self_event_tx
+                        .send(InternalInternalEvent::OneBotEvent(Box::new(
+                            InternalEvent::DriverEvent(value),
+                        )))
+                        .await
+                        .expect("Kovi kernel encountered an unrecoverable error during message forwarding (channel closed)");
+                }
+            }
+        }
+
+        // 连接断开（服务端关闭或网络错误），等待后重连
+        eprintln!(
+            "Driver event channel {}; reconnecting in {retry_delay:?}",
+            if connection_lost { "lost" } else { "ended" }
+        );
+        tokio::time::sleep(retry_delay).await;
+        retry_delay = (retry_delay * 2).min(max_delay);
     }
 }
 
@@ -112,4 +143,82 @@ async fn send_api_inner(
            Box::new(InternalEvent::DriverApiEvent((send_api, result))),
         ))
         .await.expect("Kovi kernel encountered an unrecoverable error during message forwarding (channel closed)");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::driver::{AnyError, MessageEventRegister};
+    use async_trait::async_trait;
+    use futures::Stream;
+    use serde_json::json;
+    use std::pin::Pin;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    /// 模拟驱动：每次 `event_channel` 返回一段事件流。
+    /// 第一次连接发一条事件后流立即结束（模拟服务端断开）；
+    /// 重连后发一条事件并保持在线。
+    struct FakeDriver {
+        connect_count: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Driver for FakeDriver {
+        async fn event_channel(
+            &self,
+        ) -> Result<Pin<Box<dyn Stream<Item = Result<DriverEvent, AnyError>> + Send>>, AnyError>
+        {
+            let n = self.connect_count.fetch_add(1, Ordering::SeqCst) + 1;
+            let events = vec![Ok(DriverEvent::Normal(json!({ "conn": n })))];
+            let iter = futures::stream::iter(events);
+
+            let stream: Pin<Box<dyn Stream<Item = Result<DriverEvent, AnyError>> + Send>> =
+                if n == 1 {
+                    // 第一次连接：事件后流结束，模拟服务端断开
+                    Box::pin(iter)
+                } else {
+                    // 重连成功：事件后保持在线
+                    Box::pin(iter.chain(futures::stream::pending()))
+                };
+            Ok(stream)
+        }
+
+        fn api_handler(&self, _: crate::bot::SendApi) -> crate::driver::ApiHandlerResult {
+            Box::pin(async { unreachable!() })
+        }
+
+        fn message_event_register(&self) -> MessageEventRegister {
+            MessageEventRegister {
+                type_de: Arc::new(|_, _, _| None),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn event_connect_reconnects_after_disconnect() {
+        let connect_count = Arc::new(AtomicUsize::new(0));
+        let drive = Arc::new(FakeDriver {
+            connect_count: Arc::clone(&connect_count),
+        });
+
+        let (tx, mut rx) = mpsc::channel::<InternalInternalEvent>(32);
+        let handle = tokio::spawn(event_connect(tx, drive));
+
+        // 第一次连接的事件
+        let first = rx.recv().await.expect("first connection event");
+        assert!(matches!(first, InternalInternalEvent::OneBotEvent(_)));
+
+        // 流断开后应自动重连，收到第二次连接的事件
+        let second = tokio::time::timeout(Duration::from_secs(10), rx.recv())
+            .await
+            .expect("reconnect within 10s")
+            .expect("second connection event");
+        assert!(matches!(second, InternalInternalEvent::OneBotEvent(_)));
+
+        // 确认确实重连了（不是同一条流继续产出）
+        assert_eq!(connect_count.load(Ordering::SeqCst), 2);
+
+        handle.abort();
+    }
 }

--- a/kovi/src/driver.rs
+++ b/kovi/src/driver.rs
@@ -6,6 +6,7 @@ use futures_util::Stream;
 use serde_json::Value;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Duration;
 
 pub enum DriverEvent {
     /// Drive 的退出事件
@@ -19,6 +20,24 @@ pub type AnyError = Box<dyn std::error::Error + Send + Sync>;
 pub type ApiHandlerResult =
     Pin<Box<dyn Future<Output = Result<Result<ApiReturn, ApiReturn>, AnyError>> + Send>>;
 
+/// 事件通道断开后的自动重连参数
+#[derive(Debug, Clone, Copy)]
+pub struct ReconnectConfig {
+    /// 首次重连延迟
+    pub base_delay: Duration,
+    /// 重连延迟上限
+    pub max_delay: Duration,
+}
+
+impl Default for ReconnectConfig {
+    fn default() -> Self {
+        Self {
+            base_delay: Duration::from_secs(1),
+            max_delay: Duration::from_secs(30),
+        }
+    }
+}
+
 #[async_trait::async_trait]
 pub trait Driver: Send + Sync {
     async fn event_channel(
@@ -28,6 +47,11 @@ pub trait Driver: Send + Sync {
     fn api_handler(&self, value: SendApi) -> ApiHandlerResult;
 
     fn message_event_register(&self) -> MessageEventRegister;
+
+    /// 事件通道断开后的重连参数，默认 1s 起步、指数增长、30s 封顶
+    fn reconnect_config(&self) -> ReconnectConfig {
+        ReconnectConfig::default()
+    }
 }
 
 pub struct MessageEventRegister {


### PR DESCRIPTION
# WS 断开后自动重连，不再退出程序

服务端断开连接时程序会直接退出（milky / onebot 事件通道报错、onebot API 通道收到 Close），服务端正常关闭时则会挂死。现在改为自动重连：断开后自己重试，只有收到退出信号或驱动器主动退出才停止。

## Feat

- 核心事件通道改为自动重连：断开（网络错误或正常关闭）后按 1s、2s、4s… 递增的间隔重试，连上就重新从 1s 开始；默认封顶 30s，可由驱动器自定义
- `Driver` 特征新增 `reconnect_config()`，驱动器可自定义重试间隔和上限，不影响第三方驱动器
- `kovi-onebot` 配置新增 `[reconnect]` 表（`base_delay_secs` / `max_delay_secs`），旧配置文件自动补默认值

## Fix

- 修复：WS 服务端断开时程序退出（milky / onebot 事件通道）
- 修复：服务端正常关闭连接时程序挂死（事件流静默结束，既不退出也不重连）
- 修复：onebot API 连接断开后不会重新建立，API 永远失败；现在断开后下一次调用会自动重连

## Refactor

- 删掉了 API 连接断开时通知核心退出的那套机制；`DriverEvent::Exit` 事件保留，第三方驱动器想用还能用
- API 连接从"只建一次、断了就废"改成"断了能重新建"：断开时丢掉旧连接，下一次调用自动建新的

## Test

- 核心：模拟事件流断开后自动重连
- onebot：本地 WS 服务端分别以正常 Close 和直接断连两种方式断开，验证自动重连与 API 恢复
- 配置：自定义重连参数生效，非法值（0、max 小于 base）归一化